### PR TITLE
Style tweaks 🎃

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,9 @@
 <header class="site-header px2 px-responsive">
   <div class="mt2 wrap">
     <div class="measure">
-      <a href="{{ site.url }}" class="site-title">{{ site.title }}</a>
+      <h1 class="h3 site-title">
+        <a class="site-title-link" href="{{ site.url }}">{{ site.title }}</a>
+      </h1>
       <nav class="site-nav">
         {% include navigation.html %}
       </nav>

--- a/_includes/post_summary.html
+++ b/_includes/post_summary.html
@@ -1,0 +1,24 @@
+<div class="post py3">
+  <p class="post-meta">{{ post.date | date: site.date_format }}</p>
+  <a href="{{ post.url | prepend: site.baseurl }}" class="post-link">
+    <h3 class="h2 post-title">{{ post.title }}</h3>
+  </a>
+    {% if post.file %}
+      <div class="audio-player">
+        <audio src="{{ post.file }}" preload="none" controls="controls" type="audio/mp3">
+          Your browser doesn't support the <code>audio</code> element.
+        </audio>
+
+        <a href="{{ post.file }}">Download</a>
+      </div>
+    {% endif %}
+
+
+  <p class="post-summary">
+    {% if post.summary %}
+      {{ post.summary }}
+    {% else %}
+      {{ post.excerpt }}
+    {% endif %}
+  </p>
+</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -27,15 +27,13 @@ layout: default
 <article class="post-content">
 
   {% if page.file %}
-    <audio src="{{ page.file }}" preload="none" controls="controls" type="audio/mp3">
-      Your browser doesn't support the <code>audio</code> element.
-    </audio>
+    <div class="audio-player">
+      <audio src="{{ page.file }}" preload="none" controls="controls" type="audio/mp3">
+        Your browser doesn't support the <code>audio</code> element.
+      </audio>
 
-    <a href="{{ page.file }}">Download</a>
-  {% endif %}
-
-  {% if page.soundcloud %}
-    {{ page.soundcloud }}
+      <a href="{{ page.file }}">Download</a>
+    </div>
   {% endif %}
 
   {{ content }}

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -12,6 +12,12 @@
 
 .site-header .site-title {
   font-size: $h2;
+  font-family: $font-family;
+  margin: 0;
+}
+
+.site-title .site-title-link {
+  font-size: inherit;
 }
 
 .site-nav {

--- a/_sass/_media-queries.scss
+++ b/_sass/_media-queries.scss
@@ -27,7 +27,7 @@
 
   .site-header .site-nav {
     float: right;
-    margin-top: .25rem;
+    margin-top: 0;
   }
 
   blockquote {

--- a/_sass/_posts.scss
+++ b/_sass/_posts.scss
@@ -46,3 +46,13 @@
 .related-post-title {
   border-bottom: thin solid #f3f3f3;
 }
+
+.audio-player {
+  align-items: center;
+  display: flex;
+  margin-bottom: 1em;
+}
+
+.audio-player audio {
+  margin-right: 1em;
+}

--- a/index.html
+++ b/index.html
@@ -7,34 +7,12 @@ layout: default
   {% if posts_count > 0 %}
     <div class="posts">
       {% for post in paginator.posts %}
-        <div class="post py3">
-          <p class="post-meta">{{ post.date | date: site.date_format }}</p>
-          <a href="{{ post.url | prepend: site.baseurl }}" class="post-link"><h3 class="h1 post-title">{{ post.title }}</h3></a>
-          <p class="post-summary">
-            {% if post.file %}
-              <audio src="{{ post.file }}" preload="none" controls="controls" type="audio/mp3">
-                Your browser doesn't support the <code>audio</code> element.
-              </audio>
-
-              <a href="{{ post.file }}">Download</a>
-            {% endif %}
-
-            {% if post.soundcloud %}
-              {{ post.soundcloud }}
-            {% endif %}
-
-            {% if post.summary %}
-              {{ post.summary }}
-            {% else %}
-              {{ post.excerpt }}
-            {% endif %}
-          </p>
-        </div>
+        {% include post_summary.html %}
       {% endfor %}
     </div>
 
     {% include pagination.html %}
   {% else %}
-    <h1 class='center'>{{ site.text.index.coming_soon }}</h3>
+    <h1 class='center'>{{ site.text.index.coming_soon }}</h1>
   {% endif %}
 </div>


### PR DESCRIPTION
Do some style tweaks.
- Use a `h1` tag for the header for ✨accessibility✨.
- Change post headings on summary page to be less gargantuan
- Style the audio player so it and the download link are vertically aligned, and add some spacing between it and stuff below it.
## Before:

<img width="1001" alt="screen shot 2016-07-31 at 10 34 06 am" src="https://cloud.githubusercontent.com/assets/72027/17277830/56c7e17a-570a-11e6-95ad-94ee99bd62c8.png">
## After:

<img width="914" alt="screen shot 2016-07-31 at 10 34 34 am" src="https://cloud.githubusercontent.com/assets/72027/17277833/66469b32-570a-11e6-9965-d7630c9df3f1.png">
