### PR TITLE
Add instructions for subscribing on the home page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,8 @@ baseurl:     ""
 url:         "https://softskills.audio"
 date_format: "%b %-d, %Y"
 logo_url: "https://download.softskills.audio/sse-logo-3.png" 
+podcast_feed_url: "https://feeds.feedburner.com/SoftSkillsEngineering"
+podcast_itunes_url: "https://itunes.apple.com/us/podcast/soft-skills-engineering/id1091341048?mt=2"
 
 # Google services
 google_verification:

--- a/index.html
+++ b/index.html
@@ -4,6 +4,14 @@ layout: default
 {% assign posts_count = (paginator.posts | size) %}
 
 <div class="home">
+  <p>A weekly podcast for developers, because it takes more than great code to be a great developer.</p>
+  <h2>Subscribe</h2>
+  <ul>
+    <li>To subscribe, search for "Soft Skills Engineering" in your favorite podcast app. Or use one of these links:</li>
+    <li>Mobile devices: <a href="{{site.podcast_itunes_url}}">tap here</a></li>
+    <li>Feed URL: <a href="{{site.podcast_feed_url}}">{{site.podcast_feed_url}}</a></li>
+  </ul>
+
   {% if posts_count > 0 %}
     <div class="posts">
       {% for post in paginator.posts %}

--- a/index.html
+++ b/index.html
@@ -4,10 +4,17 @@ layout: default
 {% assign posts_count = (paginator.posts | size) %}
 
 <div class="home">
-  <p>A weekly podcast for developers, because it takes more than great code to be a great developer.</p>
+  <p>
+  It takes more than great code to be a great developer. Soft Skills Engineering is a weekly Q &amp; A podcast about the non-technical side of software development.
+  </p>
+  <p>
+  Join <a href="https://twitter.com/djsmith42">Dave Smith</a> and <a href="https://twitter.com/jergason">Jamison Dance</a> as they answer your questions with dazzling brilliance and make <del>stupid</del> amazing jokes.
+  </p>
   <h2>Subscribe</h2>
+  <p>
+    To subscribe, search for "Soft Skills Engineering" in your favorite podcast app. Or use one of these links:
+  </p>
   <ul>
-    <li>To subscribe, search for "Soft Skills Engineering" in your favorite podcast app. Or use one of these links:</li>
     <li>Mobile devices: <a href="{{site.podcast_itunes_url}}">tap here</a></li>
     <li>Feed URL: <a href="{{site.podcast_feed_url}}">{{site.podcast_feed_url}}</a></li>
   </ul>


### PR DESCRIPTION
@jergason I think we should have subscription instructions prominently placed on the home page to make it easy for people to subscribe.

I found out that some (all?) Android devices can subscribe to iTunes podcast links. I tested with my wife's Android, which has Podcast Addict installed. It worked!
