### PR TITLE
Integrate disqus

### DIFF
--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -1,0 +1,21 @@
+{% if site.disqus_shortname %}
+  <div id="disqus_thread"></div>
+  <script>
+    var disqus_config = function () {
+      this.page.url = '{{ site.url }}{{ page.url }}';
+      this.page.identifier = '{{ page.guid }}';
+    };
+
+    (function () {
+      var d = document, s = d.createElement('script');
+      s.src = '//{{ site.disqus_shortname }}.disqus.com/embed.js';
+      s.setAttribute('data-timestamp', +new Date());
+      (d.head || d.body).appendChild(s);
+    })();
+  </script>
+
+  <noscript>
+    Please enable JavaScript to view the
+    <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a>
+  </noscript>
+{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -43,6 +43,10 @@ layout: default
   {% include share_buttons.html %}
 {% endif %}
 
+{% if page.comments %}
+  {% include disqus.html %}
+{% endif %}
+
 {% if site.show_post_footers %}
   {% include post_footer.html %}
 {% endif %}

--- a/_posts/2016-03-07-episode-1-startup-opportunities-and-switching-jobs.md
+++ b/_posts/2016-03-07-episode-1-startup-opportunities-and-switching-jobs.md
@@ -6,6 +6,7 @@ guid: aea74a8a-e4b3-11e5-9016-001c4211514f
 duration: "25:33"
 length: 186254
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-001.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-03-14-episode-2-influencing-your-team-and-dealing-with-anger.md
+++ b/_posts/2016-03-14-episode-2-influencing-your-team-and-dealing-with-anger.md
@@ -6,6 +6,7 @@ guid: 56d6dca2-d114-468a-953d-3f95b3048f59
 duration: "25:33"
 length: 34683307
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-002.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-03-21-episode-3-what-to-look-for-in-a-dev-team.md
+++ b/_posts/2016-03-21-episode-3-what-to-look-for-in-a-dev-team.md
@@ -6,6 +6,7 @@ guid: 103dab3b-0da1-4f8e-883e-59552132c115
 duration: "25:33"
 length: 30740779
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-003.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-03-31-episode-4-should-i-build-my-personal-brand.md
+++ b/_posts/2016-03-31-episode-4-should-i-build-my-personal-brand.md
@@ -6,6 +6,7 @@ guid: 45245e62-2797-4ac3-ada4-d550d12709c3
 duration: "25:33"
 length: 27917611
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-004.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-04-04-episode-5-developer-compensation.md
+++ b/_posts/2016-04-04-episode-5-developer-compensation.md
@@ -6,6 +6,7 @@ guid: c7d52477-3b2f-4d69-a5a4-8f2911ea1dfe
 duration: "25:33"
 length: 26148907
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-005.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-04-11-episode-6-speaking-at-conferences.md
+++ b/_posts/2016-04-11-episode-6-speaking-at-conferences.md
@@ -6,6 +6,7 @@ guid: bf6e52c8-6e52-411c-aed5-d36e068672c4
 duration: "25:33"
 length: 31376299
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-006.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-04-18-episode-7-finding-meaning-and-quitting-your-job.md
+++ b/_posts/2016-04-18-episode-7-finding-meaning-and-quitting-your-job.md
@@ -6,6 +6,7 @@ guid: 8a6ccbbe-125d-4c7c-8492-97e1a9a36711
 duration: "25:33"
 length: 23422891
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-007.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-04-25-episode-8-work-life-balance-and-on-boarding-new-engineers.md
+++ b/_posts/2016-04-25-episode-8-work-life-balance-and-on-boarding-new-engineers.md
@@ -6,6 +6,7 @@ guid: 2d83b763-cf40-4af5-abd4-63faaba39f9f
 duration: "25:33"
 length: 32489899
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-008.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-05-02-episode-9-deadlines-and-titles.md
+++ b/_posts/2016-05-02-episode-9-deadlines-and-titles.md
@@ -6,6 +6,7 @@ guid: 491aebda-d3fd-46a8-890a-16501a4e01b0
 duration: "25:33"
 length: 38852648
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-009.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-05-09-episode-10-mentors-and-stock-options.md
+++ b/_posts/2016-05-09-episode-10-mentors-and-stock-options.md
@@ -6,6 +6,7 @@ guid: dcaad639-fe60-4a8f-8b67-09ad1180e01e
 duration: "25:33"
 length: 37789099
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-010.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-05-16-episode-11-negotiating-offers-and-dealing-with-an-oblivious-boss.md
+++ b/_posts/2016-05-16-episode-11-negotiating-offers-and-dealing-with-an-oblivious-boss.md
@@ -6,6 +6,7 @@ guid: eff21465-3654-4130-83f0-807ed18706ab
 duration: "25:33"
 length: 38207232
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-011.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-05-23-episode-12-making-friends-at-work-and-how-to-be-good-at-being-managed.md
+++ b/_posts/2016-05-23-episode-12-making-friends-at-work-and-how-to-be-good-at-being-managed.md
@@ -6,6 +6,7 @@ guid: 0c38f219-b0d6-478e-9cc0-2e463c4dba1d
 duration: "25:33"
 length: 37945259
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-012.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-05-30-episode-13-dealing-with-a-yes-boss-and-the-difference-between-contract-and-perma.md
+++ b/_posts/2016-05-30-episode-13-dealing-with-a-yes-boss-and-the-difference-between-contract-and-perma.md
@@ -6,6 +6,7 @@ guid: 2c220437-c426-4dea-8738-47ea432f6e95
 duration: "25:33"
 length: 37945259
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-013.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-06-07-episode-14-web-developer-prejudice-and-legacy-code.md
+++ b/_posts/2016-06-07-episode-14-web-developer-prejudice-and-legacy-code.md
@@ -6,6 +6,7 @@ guid: 95f2a5cc-5488-43d6-a246-98d71ce2f53e
 duration: "25:33"
 length: 29193984
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-014.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-06-20-episode-15-working-with-non-technical-people-and-keeping-up-with-the-latest-tech.md
+++ b/_posts/2016-06-20-episode-15-working-with-non-technical-people-and-keeping-up-with-the-latest-tech.md
@@ -6,6 +6,7 @@ guid: edb64367-a604-472a-acfd-e119f4aed6de
 duration: "25:33"
 length: 29193984
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-015.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-06-27-episode-16-dealing-with-recruiters-and-learning-new-things-without-frustration.md
+++ b/_posts/2016-06-27-episode-16-dealing-with-recruiters-and-learning-new-things-without-frustration.md
@@ -6,6 +6,7 @@ guid: f68abc55-f67c-47de-a847-e8bd1215e3d0
 duration: "25:33"
 length: 26747520
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-016.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-07-04-episode-17-side-project-ideas-and-getting-fired.md
+++ b/_posts/2016-07-04-episode-17-side-project-ideas-and-getting-fired.md
@@ -6,6 +6,7 @@ guid: ba6a0893-a058-4d18-aefb-a8779e74a9e9
 duration: "25:33"
 length: 35014272
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-017.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-07-18-episode-18-dropping-out-of-college-and-preparing-for-interviews.md
+++ b/_posts/2016-07-18-episode-18-dropping-out-of-college-and-preparing-for-interviews.md
@@ -6,6 +6,7 @@ guid: ba176025-7551-476e-a026-e9d40706ad83
 duration: "25:33"
 length: 35014272
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-018.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-07-25-episode-19-firing-someone-for-a-coding-mistake-and-getting-demoted.md
+++ b/_posts/2016-07-25-episode-19-firing-someone-for-a-coding-mistake-and-getting-demoted.md
@@ -6,6 +6,7 @@ guid: 1daa52dd-70fe-448b-b65a-34d7a26c65dc
 duration: "25:33"
 length: 24534912
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-019.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-08-01-episode-20-stories-from-people-who-got-fired-and-doing-effective-code-reviews.md
+++ b/_posts/2016-08-01-episode-20-stories-from-people-who-got-fired-and-doing-effective-code-reviews.md
@@ -6,6 +6,7 @@ guid: 9afdbaac-f5e7-454c-a486-d4c3e322c5b1
 duration: "30:31"
 length: 29302656
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-020.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-08-08-episode-21-interns-and-dead-weight.md
+++ b/_posts/2016-08-08-episode-21-interns-and-dead-weight.md
@@ -6,6 +6,7 @@ guid: c073d70b-2a4b-46f4-847e-c89a1edb5676
 duration: "33:55"
 length: 32557056
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-021.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-08-15-episode-22-health-insurance-and-open-source.md
+++ b/_posts/2016-08-15-episode-22-health-insurance-and-open-source.md
@@ -6,6 +6,7 @@ guid: 9b7bbc64-f701-4262-917b-2a7912a2d2d4
 duration: "40:55"
 length: 39280512
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-022.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-08-22-episode-23-cto-questions-and-getting-a-raise.md
+++ b/_posts/2016-08-22-episode-23-cto-questions-and-getting-a-raise.md
@@ -6,6 +6,7 @@ guid: cb1d6cb4-89ef-4b39-b503-e8164abe1b29
 duration: "37:33"
 length: 27918336
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-023.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-08-29-episode-24-generalist-vs-specialist.md
+++ b/_posts/2016-08-29-episode-24-generalist-vs-specialist.md
@@ -6,6 +6,7 @@ guid: f72b7e1c-d2a1-4ad5-a9a8-8318d00efb99
 duration: "37:35"
 length: 36074880
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-024.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-09-05-episode-25-business-things-and-managing.md
+++ b/_posts/2016-09-05-episode-25-business-things-and-managing.md
@@ -6,6 +6,7 @@ guid: cdd8d25d-e37f-44ea-b783-329748c3bee9
 duration: "38:49"
 length: 37270272
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-025.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-09-12-episode-26-communicate-your-efforts-and-i-told-you-so.md
+++ b/_posts/2016-09-12-episode-26-communicate-your-efforts-and-i-told-you-so.md
@@ -6,6 +6,7 @@ guid: 461aab20-b759-4706-a6b4-039b1d4dd298
 duration: "41:10"
 length: 39514752
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-026.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-09-19-episode-27-resumes-and-non-engineering-tasks.md
+++ b/_posts/2016-09-19-episode-27-resumes-and-non-engineering-tasks.md
@@ -6,6 +6,7 @@ guid: f78ecf48-7665-4ede-8bda-d342a3c1fd6c
 duration: "42:41"
 length: 40977408
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-027.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-09-26-episode-28-tenure-and-helping-junior-developers.md
+++ b/_posts/2016-09-26-episode-28-tenure-and-helping-junior-developers.md
@@ -6,6 +6,7 @@ guid: e88d9b23-eb6d-4d4e-86cd-bc3e2fdba9a1
 duration: "34:48"
 length: 33414912
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-028.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-10-06-episode-29-starting-a-new-job.md
+++ b/_posts/2016-10-06-episode-29-starting-a-new-job.md
@@ -6,6 +6,7 @@ guid: 8bf2b2ae-b180-4a93-8bf8-0c63cd49ecf8
 duration: "21:25"
 length: 20567040
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-029.mp3"
+comments: true
 categories: episode
 redirect_from: "/2016/10/07/starting-a-new-job/"
 ---

--- a/_posts/2016-10-10-episode-30-consensus-and-code-eiditing-etiquette.md
+++ b/_posts/2016-10-10-episode-30-consensus-and-code-eiditing-etiquette.md
@@ -6,6 +6,7 @@ guid: 4145ff3c-309a-49e4-a2ed-1e584b737933
 duration: "40:29"
 length: 38868096
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-030.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-10-17-episode-31-management-and-knowing-if-a-job.md
+++ b/_posts/2016-10-17-episode-31-management-and-knowing-if-a-job.md
@@ -6,6 +6,7 @@ guid: 76e67698-7853-496a-9603-15b3fec71e1b
 duration: "33:10"
 length: 31833216
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-031.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-10-26-episode-32-why-do-contracting.md
+++ b/_posts/2016-10-26-episode-32-why-do-contracting.md
@@ -6,6 +6,7 @@ guid: 7657c44c-0124-46f9-ac1e-d3c7cbd4438a
 duration: "16:29"
 length: 15827277
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-032.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-10-31-episode-33-damaging-your-credibility-and-meeting-employers-in-school.md
+++ b/_posts/2016-10-31-episode-33-damaging-your-credibility-and-meeting-employers-in-school.md
@@ -6,6 +6,7 @@ guid: 1e9f9b30-67c1-49ce-a161-1c58fec198d2
 duration: "33:38"
 length: 32292864
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-033.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_posts/2016-11-07-episode-34-certifications-and-avoidance.md
+++ b/_posts/2016-11-07-episode-34-certifications-and-avoidance.md
@@ -6,6 +6,7 @@ guid: 9fd63016-7b1b-4441-b387-16cf944b8d3e
 duration: "29:23"
 length: 28208900
 file: "https://dts.podtrac.com/redirect.mp3/download.softskills.audio/sse-034.mp3"
+comments: true
 categories: episode
 ---
 

--- a/_sass/_disqus.scss
+++ b/_sass/_disqus.scss
@@ -1,0 +1,3 @@
+#disqus_thread {
+  margin-top: 50px;
+}

--- a/css/pixyll.scss
+++ b/css/pixyll.scss
@@ -33,3 +33,4 @@
 @import 'gists';
 @import 'measure';
 @import 'pagination';
+@import 'disqus';


### PR DESCRIPTION
This PR is ready to merge but requires one extra change from your side - updating `disqus_shortname` property in `_config.yml` e.g.

```
# Disqus post comments
# (leave blank to disable Disqus)
disqus_shortname: soft-skills-engineering-unofficial
```

You can [register the site in a few minutes here](http://disqus.com/register).

I was thinking about hiding comments by default and showing a button (with comments counter) to load them. But if someone navigated to details page he expects to see more details about the episode instantly. Currently post summary on index page is almost identical to its details page so having disqus autoinitialized looks good.

Another thing I thought about is displaying comments counter next to "Download" link on index page but it is rather "nice to have" feature which may be added in the future.

How it looks like:

![image](https://cloud.githubusercontent.com/assets/744568/20303720/1237d5b6-ab2d-11e6-9abc-08a6afbab468.png)
