### PR TITLE
Post details on home page

### DIFF
--- a/_includes/post_summary.html
+++ b/_includes/post_summary.html
@@ -15,10 +15,6 @@
 
 
   <p class="post-summary">
-    {% if post.summary %}
-      {{ post.summary }}
-    {% else %}
-      {{ post.excerpt }}
-    {% endif %}
+    {{ post.content }}
   </p>
 </div>

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sudo gem install bundler \
+  && bundle install \
+  && bundle exec jekyll serve --watch


### PR DESCRIPTION
@jergason I think it's weird that we only show the first sentence of each post on the home page.  It usually would say "In this episode, Jamison and Dave talk about:" and then abruptly end.

This changes it to show the full content, which is not very long and looks good to me.