### PR TITLE
change upload script to correctly prefix episode number in url

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -17,7 +17,8 @@ byte_size=`ls -nl "$1" | awk '{print $5}'`
 duration=`mp3info -p "%m:%02s" $1`
 episode_number=`echo "$1" | perl -ne'/episode-(\d+)\.mp3/ && print $1'`
 uuid=`uuidgen | perl -ne 'print lc'`
-new_filename="sse-$(printf '%03d' $episode_number).mp3"
+prefixed_episode_number="$(printf '%03d' $episode_number)"
+new_filename="sse-${prefixed_episode_number}.mp3"
 post_date=`date "+%Y-%m-%d 12:00:00 -0700"`
 
 
@@ -26,7 +27,7 @@ perl -pi -e"s/guid: .*/guid: ${uuid}/" $2
 perl -pi -e"s/date: .*/date: ${post_date}/" $2
 perl -pi -e"s/duration: .*/duration: \"${duration}\"/" $2
 perl -pi -e"s/length: .*/length: ${byte_size}/" $2
-perl -pi -e"s/sse-(\d+)\.mp3/sse-${episode_number}\.mp3/" $2
+perl -pi -e"s/sse-(\d+)\.mp3/sse-${prefixed_episode_number}\.mp3/" $2
 
 scp $1 ssh.thesmithfam.org:~/podcasts/${new_filename}
 


### PR DESCRIPTION
The script was changed to pad episode numbers to zero digits. However, the url pointing to the file was not correctly padded, which means attempts to download the file failed. This fixes the script to make the url match the filename.