### PR TITLE
add slack welcome and code of conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -46,8 +46,6 @@ This community is mostly not a place for obvious commercial activity such as rec
 * #remote-jobs
 * #services
 
-Additionally, geographically-focused channels (i.e. #colorado-connections, #new-york-city, similar) have a higher tolerance for specific kinds of commercial activity focused on events based in that region.
-
 Non-obvious commercial activity is less obvious. Well-intentioned user surveys of a specific channel are a common request and we ask that you:
 
 * Ask permission of the channel.
@@ -56,7 +54,7 @@ Non-obvious commercial activity is less obvious. Well-intentioned user surveys o
 
 We believe the above protocol is a useful approach for other types of non-obvious commercial activity.
 
-If you join this community simply to take value from the community rather than contribute, the community will quickly notice and react. If you are wondering whether a specific action is commercial or not, please ask and calibrate in #rands-slack-rules.
+If you join this community simply to take value from the community rather than contribute, the community will quickly notice and react. If you are wondering whether a specific action is commercial or not, please ask and calibrate in #slack-rules.
 
 ## Resolve Peacefully
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,98 @@
+---
+layout: page
+title: Soft Skills Engineering Slack Team Code of Conduct
+permalink: /code-of-conduct
+---
+All participants in the Soft Skills Engineering Slack are required to comply with the following Code of Conduct. Administrators (see below for definition of administrators) will enforce this code throughout the Soft Skills Engineering Slack.
+
+# The Short Version
+
+Be respectful of other people; respectfully ask people to stop if you are bothered; respect privacy; understand we're mostly not-for-profit; and if you can’t resolve an issue then contact the Administrators. If you are being a problem, it will be apparent and you may be asked to leave the Soft Skills Engineering Slack.
+
+# The Long Version
+
+## Respect
+
+The Soft Skills Engineering Slack is an intentionally positive community that recognizes and celebrates the creativity and collaboration of independent members and the diversity of skills, talents, experiences, cultures, and opinions that they bring to our community.
+
+The Soft Skills Engineering Slack is an inclusive environment, based on treating all individuals respectfully, regardless of gender or gender identity (including transgender status), sexual orientation, age, disability, nationality, ethnicity, religion (or lack thereof), or career path.
+
+We value respectful behavior above individual opinions.
+
+Respectful behavior includes but is not limited to:
+
+* Be considerate, kind, constructive, and helpful.
+* Avoid demeaning, discriminatory, harassing, hateful, or physically threatening behavior, speech, and imagery.
+* If you’re not sure, ask someone instead of assuming. No, really. Just ask the administrators. We’d rather hear from you than hear about something you said or did after the fact, and we are here to help.
+* Don’t be a bystander. Role model respectful behaviour, but also help to address disrespect when you see it. 
+
+Disrespectful behavior outside this community may be considered a violation of this code of conduct at the discretion of the Administrators.
+
+## Privacy
+
+This community is not a public space. However, no one has signed an non-disclosure agreement (“NDA”) to participate, and you should not presume anything you say here will remain private, so act accordingly. Protect IP and legally-protected information.
+
+If you want to publicly disclose anything discussed here, use the [Chatham House Rule](https://www.chathamhouse.org/about/chatham-house-rule) as the guideline (“participants are free to use the information received, but neither the identity nor the affiliation of the speaker(s), nor that of any other participant, may be revealed”).
+
+For attribution of specific content found on this Slack, we ask that you ask the originator of the content for permission. If you don’t receive consent in a reasonable period of time, we ask that you credit the “Soft Skills Engineering Slack.”
+
+## Not For Profit
+
+This community is mostly not a place for obvious commercial activity such as recruiting or marketing except in channels dedicated to that purpose which include:
+
+* #conferences
+* #consulting-gigs
+* #jobs
+* #remote-jobs
+* #services
+
+Additionally, geographically-focused channels (i.e. #colorado-connections, #new-york-city, similar) have a higher tolerance for specific kinds of commercial activity focused on events based in that region.
+
+Non-obvious commercial activity is less obvious. Well-intentioned user surveys of a specific channel are a common request and we ask that you:
+
+* Ask permission of the channel.
+* State clear intent for the purpose of the survey.
+* Listen to the response of your peers.
+
+We believe the above protocol is a useful approach for other types of non-obvious commercial activity.
+
+If you join this community simply to take value from the community rather than contribute, the community will quickly notice and react. If you are wondering whether a specific action is commercial or not, please ask and calibrate in #rands-slack-rules.
+
+## Resolve Peacefully
+
+We believe peer-to-peer discussions, feedback, and corrections can help build a stronger, safer, and more welcoming community.
+
+If you see someone violating any part of this Code of Conduct, we urge you to respectfully dissuade them from such behavior. Expect that others in the community wish to help keep the community respectful, and welcome your input in doing so.
+
+If you experience disrespectful behavior toward yourself or anyone else and feel in any way unable or unwilling to respond or resolve it respectfully (for any reason), please immediately bring it to the attention of an Administrator. We want to hear from you about anything that you feel is disrespectful, threatening, or just something that could make someone feel distressed in any way. We will listen and work to resolve the matter.
+
+## Apologize for Mistakes
+
+Should you catch yourself behaving disrespectfully, or be confronted as such, listen intently, own up to your words and actions, and apologize accordingly. No one is perfect, and even well-intentioned people make mistakes. What matters is how you handle them and that you avoid repeating them in the future.
+
+## Consequences
+
+If you are unable to resolve a situation peacefully, please refer to our [Incident Process](/incident-process) and choose a course of action that suits the situation. 
+
+If the Administrators determine that a human is violating any part of this Code of Conduct, the Administrators may take any action they deem appropriate within this Slack team, up to and including expulsion and exclusion from the Soft Skills Engineering Slack.
+
+As Administrators, we will seek to resolve conflicts peacefully and in a manner that is positive for the community. We can’t foresee every situation, and thus if in the Administrator's judgment the best thing to do is to ask a disrespectful individual to leave, we will do so. 
+
+## Administrators
+
+The administrator(s) of Soft Skills Engineering as of June 18th, 2019:
+
+@jamison ([Jamison Dance](mailto:hi@jamison.dance))
+
+## Thanks
+
+Thank you to every Soft Skills Engineering Slack community member for helping to make our home the respectful and inclusive community that it is.
+
+Thank you to the [Rands Leadership Slack](https://github.com/randsleadershipslack/documents-and-resources/blob/master/code-of-conduct.md), which we cribbed this from.
+
+
+Special thanks to [Chicago Camps](http://chicagocamps.org/code-of-conduct/), YxYY ([Yes and Yes Yes](http://www.yesandyesyes.com/)), and Hillary Hartley for sharing their Code of Conduct with us. We consider them as examples to look up to and emulate. We also thank the YxYY community member [Tantek Çelik](http://tantek.com/), and the other organizers of [IndieWebCamp](http://indiewebcamp.com/) for creating and sharing the [Code of Conduct](http://indiewebcamp.com/code-of-conduct) on which this one is based. If you question the need for a Code of Conduct, please see [this](http://indiewebcamp.com/code-of-conduct-why).
+
+V1.0 of this Code of Conduct was published on June 18th, 2019.
+
+This Code of Conduct is released under the [CC0 public domain license](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/incident-process.md
+++ b/incident-process.md
@@ -1,0 +1,62 @@
+---
+layout: page
+title: Soft Skills Engineering Slack Team Incident Process
+permalink: /incident-process
+---
+# Things Sometimes Go Sideways
+
+In any group of humans, things will sometimes go sideways. Whether it's simple unintentional miscommunication or more extreme unacceptable behavior, we need to have an agreed upon protocol to resolve these situations ourselves or to escalate in the case that one-to-one resolutions are unachievable. 
+
+This is the process for incident resolution at Soft Skills Engineering Slack and process is [documented culture](http://randsinrepose.com/archives/the-process-myth/).
+
+# The Process
+
+## Resolve Peacefully 
+
+When an incident occurs, we ask that per the [Code of Conduct](https://github.com/randsleadershipslack/documents-and-resources/blob/master/code-of-conduct.md) for those involved to resolve peacefully:
+
+“If you see someone violating any part of this Code of Conduct, we urge you to respectfully dissuade them from such behavior. Expect that others in the community wish to help keep the community respectful, and welcome your input in doing so.”
+
+This is easier said than done, but this is Soft Skills Engineering Slack. Our expectations are that everyone here is hoping to learn about the craft of leadership; peaceful resolution of complex human situations is leadership 101.
+
+## Escalation
+
+Resolution amongst the individuals will not always be achievable. In this case, the reporter or observer of the incident has a choice. They can share the incident with #rands-slack-rules to seek feedback, and perhaps resolve the incident, or they can raise the incident with the Administrators (see below for specifics). We understand the need for the latter workflow, but we highly encourage the former because, again, this is a community focused on leadership. Our hope is that the debate will help educate this sub-community of humans interested in the rules and culture that govern this small corner of the Internet. 
+
+There are two paths in reporting an incident to an Administrator: filing a formal complain and raising a concern. For a formal complaint, the reporter needs to send an Administrator a direct message with the following information:
+
+1. What’s the nature of the incident or Code of Conduct violation?
+2. Who is involved in this incident?
+3. What material supports this situation?
+4. Any privacy concerns? (Reporter consent is required before sharing any information regarding the incident)
+
+The second reporting path is raising a concern. We ask the reporter provide the same information with the understanding the reporter *is not* looking for resolution, but wants to provide Administrators a heads up regarding behavior within the community. 
+
+For both paths, with this information in hand, the Administrators will strive to respond to the reporter as quickly as possible with an estimate of when they think they’ll be able to triage and resolve this incident. In the case of a raised concern, the understanding is there *may be no action* other than administrative awareness. 
+
+In extreme cases involving formal complaints, the Administrator may suspend one or more accounts until they are able to triage and resolve an incident.
+
+Incident resolution can vary from hours to days depending on the availability of those involved. Once the incident is resolved, the Administrators will communicate the resolution to the reporter and other parties relevant to the incident.
+
+Incidents are confidential. The administrator will not provide any information to parties not involved in an incidents. The lone exception is the case where an incident occurs in a public channel, the administrator will consult those involved in the incident before disclosing any information.
+
+## Appeal of Account Suspension
+
+In cases that result in account suspension, the individual suspended may appeal the decision starting one week after the suspension by sending a mail to an Administrator with justification for overturning the appeal. If a suspension is overturned, the new context will be shared with #rands-slack-rules
+
+# FAQ:
+
+- “Is situation XYZ an incident?” Unsure if there’s a CoC violation? Ask in #rands-slack-rules and/or DM the administrator. We'll help. 
+- “How many incidents have you handled since this place started?” Fifteen as of April 2019.
+
+## Administrators
+
+The administrator(s) of the Soft Skills Engineering Slack as of June 18th, 2019:
+
+@jamison ([Jamison Dance](mailto:hi@jamison.dance))
+
+## Version and Copyright
+
+V1.0 of this Code of Conduct was published on June 18th, 2019.
+
+This Code of Conduct is released under the [CC0 public domain license](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/incident-process.md
+++ b/incident-process.md
@@ -13,15 +13,15 @@ This is the process for incident resolution at Soft Skills Engineering Slack and
 
 ## Resolve Peacefully 
 
-When an incident occurs, we ask that per the [Code of Conduct](https://github.com/randsleadershipslack/documents-and-resources/blob/master/code-of-conduct.md) for those involved to resolve peacefully:
+When an incident occurs, we ask that per the [Code of Conduct](/code-of-conduct) for those involved to resolve peacefully:
 
 “If you see someone violating any part of this Code of Conduct, we urge you to respectfully dissuade them from such behavior. Expect that others in the community wish to help keep the community respectful, and welcome your input in doing so.”
 
-This is easier said than done, but this is Soft Skills Engineering Slack. Our expectations are that everyone here is hoping to learn about the craft of leadership; peaceful resolution of complex human situations is leadership 101.
+This is easier said than done, but this is the Soft Skills Engineering Slack. Our expectations are that everyone here is hoping to learn about the craft of soft skills; peaceful resolution of complex human situations is an essential soft skill.
 
 ## Escalation
 
-Resolution amongst the individuals will not always be achievable. In this case, the reporter or observer of the incident has a choice. They can share the incident with #rands-slack-rules to seek feedback, and perhaps resolve the incident, or they can raise the incident with the Administrators (see below for specifics). We understand the need for the latter workflow, but we highly encourage the former because, again, this is a community focused on leadership. Our hope is that the debate will help educate this sub-community of humans interested in the rules and culture that govern this small corner of the Internet. 
+Resolution amongst the individuals will not always be achievable. In this case, the reporter or observer of the incident has a choice. They can share the incident with #slack-rules to seek feedback, and perhaps resolve the incident, or they can raise the incident with the Administrators (see below for specifics). We understand the need for the latter workflow, but we encourage the former because, again, this is a community focused on soft skills. Our hope is that the debate will help educate this sub-community of humans interested in the rules and culture that govern this small corner of the Internet. 
 
 There are two paths in reporting an incident to an Administrator: filing a formal complain and raising a concern. For a formal complaint, the reporter needs to send an Administrator a direct message with the following information:
 
@@ -42,12 +42,12 @@ Incidents are confidential. The administrator will not provide any information t
 
 ## Appeal of Account Suspension
 
-In cases that result in account suspension, the individual suspended may appeal the decision starting one week after the suspension by sending a mail to an Administrator with justification for overturning the appeal. If a suspension is overturned, the new context will be shared with #rands-slack-rules
+In cases that result in account suspension, the individual suspended may appeal the decision starting one week after the suspension by sending a mail to an Administrator with justification for overturning the appeal. If a suspension is overturned, the new context will be shared with #slack-rules
 
 # FAQ:
 
-- “Is situation XYZ an incident?” Unsure if there’s a CoC violation? Ask in #rands-slack-rules and/or DM the administrator. We'll help. 
-- “How many incidents have you handled since this place started?” Fifteen as of April 2019.
+- “Is situation XYZ an incident?” Unsure if there’s a CoC violation? Ask in #slack-rules and/or DM the administrator. We'll help. 
+- “How many incidents have you handled since this place started?” None as of June 2019.
 
 ## Administrators
 

--- a/incident-process.md
+++ b/incident-process.md
@@ -23,7 +23,7 @@ This is easier said than done, but this is the Soft Skills Engineering Slack. Ou
 
 Resolution amongst the individuals will not always be achievable. In this case, the reporter or observer of the incident has a choice. They can share the incident with #slack-rules to seek feedback, and perhaps resolve the incident, or they can raise the incident with the Administrators (see below for specifics). We understand the need for the latter workflow, but we encourage the former because, again, this is a community focused on soft skills. Our hope is that the debate will help educate this sub-community of humans interested in the rules and culture that govern this small corner of the Internet. 
 
-There are two paths in reporting an incident to an Administrator: filing a formal complain and raising a concern. For a formal complaint, the reporter needs to send an Administrator a direct message with the following information:
+There are two paths in reporting an incident to an Administrator: filing a formal complaint and raising a concern. For a formal complaint, the reporter needs to send an Administrator a direct message with the following information:
 
 1. What’s the nature of the incident or Code of Conduct violation?
 2. Who is involved in this incident?

--- a/slack.md
+++ b/slack.md
@@ -1,13 +1,13 @@
 ---
 layout: page
-title: Soft Skills Engineering Slack Team
+title: Slack
 permalink: /slack
 tags: about
 ---
 
-> Want an invite? Anyone who donates to the [Soft Skills Engineering Patreon](https://www.patreon.com/SoftSkillsEng) gets an invite to the Slack team.
+> Want an invite? Anyone who donates to the [Soft Skills Engineering Patreon](https://www.patreon.com/SoftSkillsEng) gets an invite to the Slack.
 
-Welcome to the Soft Skills Engineering Slack team! We're excited to have you join this community interested in the non-technical parts of the technical field of software. These guidelines will help keep the environment safe, welcoming, and friendly.
+Welcome to the Soft Skills Engineering Slack! We're excited to have you join this community interested in the non-technical parts of the technical field of software. These guidelines will help keep the environment safe, welcoming, and friendly.
 
 ## Guidelines
 1. Hop in to #intros and introduce yourself. Help us get to know you!

--- a/slack.md
+++ b/slack.md
@@ -5,7 +5,7 @@ permalink: /slack
 tags: about
 ---
 
-> Want an invite? Anyone who donates to the [Soft Skills Engineering Patreon](https://www.patreon.com/SoftSkillsEng) gets an invite to the Slack.
+> Want an invite? Anyone who donates to the [Soft Skills Engineering Patreon](https://www.patreon.com/SoftSkillsEng) gets an invite to the Slack. Invites are sent the week of each month after Patreon bills you.
 
 Welcome to the Soft Skills Engineering Slack! We're excited to have you join this community interested in the non-technical parts of the technical field of software. These guidelines will help keep the environment safe, welcoming, and friendly.
 

--- a/slack.md
+++ b/slack.md
@@ -2,6 +2,7 @@
 layout: page
 title: Soft Skills Engineering Slack Team
 permalink: /slack
+tags: about
 ---
 
 > Want an invite? Anyone who donates to the [Soft Skills Engineering Patreon](https://www.patreon.com/SoftSkillsEng) gets an invite to the Slack team.

--- a/slack.md
+++ b/slack.md
@@ -1,0 +1,21 @@
+---
+layout: page
+title: Soft Skills Engineering Slack Team
+permalink: /slack
+---
+
+> Want an invite? Anyone who donates to the [Soft Skills Engineering Patreon](https://www.patreon.com/SoftSkillsEng) gets an invite to the Slack team.
+
+Welcome to the Soft Skills Engineering Slack team! We're excited to have you join this community interested in the non-technical parts of the technical field of software. These guidelines will help keep the environment safe, welcoming, and friendly.
+
+## Guidelines
+1. Hop in to #intros and introduce yourself. Help us get to know you!
+2. Fill out your profile. Make yourself a human.
+3. Read the [Code of Conduct](/code-of-conduct).
+4. Remmeber that everyone is welcome to contribute regardless of experience level or background. If you just want to hang back and lurk, that’s cool too.
+5. This Slack is not a place for commercial activity (e.g. recruiting, or marketing your product/conference) except in channels dedicated to that purpose (e.g. #jobs, #consulting-gigs, #conferences, or #services) and never in an unsolicited direct message. If you see commercial behavior going down, direct message @jamison and I’ll fix it.
+6. Really, read the [Code of Conduct](/code-of-conduct).
+
+We're so glad you're joining us. See you on Slack!
+
+<small>Thanks to the Rands in Repose [Slack guidelines](https://randsinrepose.com/welcome-to-rands-leadership-slack/) which influenced this document.</small>


### PR DESCRIPTION
Add a slack welcome page (slack.md), which links to a code of conduct and incident process.

I took most of this from the Rands in Repose leadership slack. I read through it a few times and tweaked it a bit and broadly agree with it now, but I'd appreciate feedback on guidelines, process, and anything else.

Once this is ready to merge the plan is to have a bot welcome new users and point them to this page.

A few things I'm not sure of: 
* Should this be in the menu? This change adds it as a menu item, but maybe it doesn't need to be there?
* Do you want to be listed as an admin as well?