### PR TITLE
Home page: Move the recent episode list below the tweets

### DIFF
--- a/_sass/_hero.scss
+++ b/_sass/_hero.scss
@@ -3,11 +3,11 @@
 }
 
 .hero.icon-pattern {
-  padding-bottom: calc(18vw - 2.5rem);
+  padding-bottom: calc(28vw - 2.5rem);
   background-image: url(/img/icon-pattern.svg);
-  background-position: center bottom -15vw;
+  background-position: center top;
   background-repeat: no-repeat;
-  background-size: cover;
+  background-size: contain;
 }
 
 .hero .container {
@@ -38,10 +38,6 @@
 
 
 @media (min-width: 768px) {
-  .hero.icon-pattern {
-    background-size: cover;
-  }
-
   .hero h1 {
     font-size: 4rem;
   }

--- a/index.html
+++ b/index.html
@@ -56,8 +56,35 @@ layout: default
     </p>
     </section>
   </div>
-</div>
+  <header class="block-header text-center">
+    <div class="container">
+      <img
+        src="/img/talk.svg"
+        alt="A speech bubble"
+        width="140" />
+      <h2 class="block-heading type-h1">Why should you listen?</h2>
+      <p class="lead">Here's what listeners say:</p>
+    </div>
+  </header>
+  <section class="quotes-grid">
+    <blockquote class="twitter-tweet"><p lang="en" dir="ltr">Started listening to <a href="https://twitter.com/SoftSkillsEng?ref_src=twsrc%5Etfw">@SoftSkillsEng</a> and it’s such a great resource! People often forget how important soft skills are especially in the dev world. It’s definitely something that you can invest in now that will benefit you during your whole career!</p>&mdash; Kyle 🤙 (@DesignByKyle) <a href="https://twitter.com/DesignByKyle/status/1164216658933817344?ref_src=twsrc%5Etfw">August 21, 2019</a></blockquote>
 
+    <blockquote class="twitter-tweet"><p lang="en" dir="ltr">Hands down <a href="https://twitter.com/SoftSkillsEng?ref_src=twsrc%5Etfw">@SoftSkillsEng</a> has the best intros. I&#39;m in tears most of the times 😂😂😂</p>&mdash; Bassam Ismail 🚴 (@skippednote) <a href="https://twitter.com/skippednote/status/1163374922518761477?ref_src=twsrc%5Etfw">August 19, 2019</a></blockquote>
+
+    <blockquote class="twitter-tweet"><p lang="en" dir="ltr">Being a good software engineer also means that you focus on soft skills as well. Let me recommend a great podcast from <a href="https://twitter.com/jamison_dance?ref_src=twsrc%5Etfw">@jamison_dance</a> and <a href="https://twitter.com/djsmith42?ref_src=twsrc%5Etfw">@djsmith42</a>, the <a href="https://twitter.com/SoftSkillsEng?ref_src=twsrc%5Etfw">@SoftSkillsEng</a>!<a href="https://t.co/l0Rq1gy8fX">https://t.co/l0Rq1gy8fX</a></p>&mdash; Gábor Horváth (@hhgabor) <a href="https://twitter.com/hhgabor/status/1162796380999626752?ref_src=twsrc%5Etfw">August 17, 2019</a></blockquote>
+
+    <blockquote class="twitter-tweet"><p lang="en" dir="ltr">.<a href="https://twitter.com/SoftSkillsEng?ref_src=twsrc%5Etfw">@SoftSkillsEng</a> continues to be my favorite podcast. I laugh at loud at least once an episode and the content is super on-point.</p>&mdash; ████ Sager (@adfontes__) <a href="https://twitter.com/adfontes__/status/1162157584087998465?ref_src=twsrc%5Etfw">August 16, 2019</a></blockquote>
+
+
+    <blockquote class="twitter-tweet"><p lang="en" dir="ltr">Listen to every episode of <a href="https://twitter.com/SoftSkillsEng?ref_src=twsrc%5Etfw">@SoftSkillsEng</a> 🤓 Nothing has a more profound impact on your career growth than soft skills.</p>&mdash; Mike Kerr (@codecareercoach) <a href="https://twitter.com/codecareercoach/status/1156657543399129088?ref_src=twsrc%5Etfw">July 31, 2019</a></blockquote>
+
+    <blockquote class="twitter-tweet"><p lang="en" dir="ltr">I just discovered <a href="https://twitter.com/SoftSkillsEng?ref_src=twsrc%5Etfw">@SoftSkillsEng</a> but it is amazing, I always learn something new from them. Also all episodes have a fun and friendly feeling</p>&mdash; Daniel Peñaloza (@danp1925) <a href="https://twitter.com/danp1925/status/1153683341369122816?ref_src=twsrc%5Etfw">July 23, 2019</a></blockquote>
+
+    <blockquote class="twitter-tweet"><p lang="en" dir="ltr">I love <a href="https://twitter.com/SoftSkillsEng?ref_src=twsrc%5Etfw">@SoftSkillsEng</a> .. although it&#39;s not directly focused on technical side of Software Engineering, it takes a huge often not-discussed part of the job such as the team communication, management, ethics, etc...<br><br>The hosts are really good, I literally listen to every episode ❤️</p>&mdash; Nigo (@lenaggar) <a href="https://twitter.com/lenaggar/status/1128405640077107203?ref_src=twsrc%5Etfw">May 14, 2019</a></blockquote>
+
+    <blockquote class="twitter-tweet"><p lang="en" dir="ltr"><a href="https://twitter.com/WanderingHogan?ref_src=twsrc%5Etfw">@WanderingHogan</a> I’ve been looking for new podcasts and added <a href="https://twitter.com/SoftSkillsEng?ref_src=twsrc%5Etfw">@SoftSkillsEng</a> when you mentioned it. Just listened to EP 149 and totally relevant to me as a 40-year-old dev. Thanks for sharing! Also, nice to hear your name in the shoutouts!</p>&mdash; Andrew Serff (@andrewserff) <a href="https://twitter.com/andrewserff/status/1114300319997939712?ref_src=twsrc%5Etfw">April 5, 2019</a></blockquote>
+  </section>
+</div>
 
 <h2 class="sr-only">Recent Episodes</h2>
 <div class="posts">
@@ -86,38 +113,6 @@ layout: default
       </div>
     </footer>
   </div>
-</div>
-
-<div class="block quotes">
-  <header class="block-header text-center">
-    <div class="container">
-      <img
-        src="/img/talk.svg"
-        alt="A speech bubble"
-        width="140" />
-      <h2 class="block-heading type-h1">Why should you listen?</h2>
-      <p class="lead">Soft Skills Engineering listeners are awesome. Here's what they are saying about the podcast.</p>
-      <p class="lead"><strong>Are you a fan?</strong> Say hello on social media!</p>
-    </div>
-  </header>
-  <section class="quotes-grid">
-    <blockquote class="twitter-tweet"><p lang="en" dir="ltr">Started listening to <a href="https://twitter.com/SoftSkillsEng?ref_src=twsrc%5Etfw">@SoftSkillsEng</a> and it’s such a great resource! People often forget how important soft skills are especially in the dev world. It’s definitely something that you can invest in now that will benefit you during your whole career!</p>&mdash; Kyle 🤙 (@DesignByKyle) <a href="https://twitter.com/DesignByKyle/status/1164216658933817344?ref_src=twsrc%5Etfw">August 21, 2019</a></blockquote>
-
-    <blockquote class="twitter-tweet"><p lang="en" dir="ltr">Hands down <a href="https://twitter.com/SoftSkillsEng?ref_src=twsrc%5Etfw">@SoftSkillsEng</a> has the best intros. I&#39;m in tears most of the times 😂😂😂</p>&mdash; Bassam Ismail 🚴 (@skippednote) <a href="https://twitter.com/skippednote/status/1163374922518761477?ref_src=twsrc%5Etfw">August 19, 2019</a></blockquote>
-
-    <blockquote class="twitter-tweet"><p lang="en" dir="ltr">Being a good software engineer also means that you focus on soft skills as well. Let me recommend a great podcast from <a href="https://twitter.com/jamison_dance?ref_src=twsrc%5Etfw">@jamison_dance</a> and <a href="https://twitter.com/djsmith42?ref_src=twsrc%5Etfw">@djsmith42</a>, the <a href="https://twitter.com/SoftSkillsEng?ref_src=twsrc%5Etfw">@SoftSkillsEng</a>!<a href="https://t.co/l0Rq1gy8fX">https://t.co/l0Rq1gy8fX</a></p>&mdash; Gábor Horváth (@hhgabor) <a href="https://twitter.com/hhgabor/status/1162796380999626752?ref_src=twsrc%5Etfw">August 17, 2019</a></blockquote>
-
-    <blockquote class="twitter-tweet"><p lang="en" dir="ltr">.<a href="https://twitter.com/SoftSkillsEng?ref_src=twsrc%5Etfw">@SoftSkillsEng</a> continues to be my favorite podcast. I laugh at loud at least once an episode and the content is super on-point.</p>&mdash; ████ Sager (@adfontes__) <a href="https://twitter.com/adfontes__/status/1162157584087998465?ref_src=twsrc%5Etfw">August 16, 2019</a></blockquote>
-
-
-    <blockquote class="twitter-tweet"><p lang="en" dir="ltr">Listen to every episode of <a href="https://twitter.com/SoftSkillsEng?ref_src=twsrc%5Etfw">@SoftSkillsEng</a> 🤓 Nothing has a more profound impact on your career growth than soft skills.</p>&mdash; Mike Kerr (@codecareercoach) <a href="https://twitter.com/codecareercoach/status/1156657543399129088?ref_src=twsrc%5Etfw">July 31, 2019</a></blockquote>
-
-    <blockquote class="twitter-tweet"><p lang="en" dir="ltr">I just discovered <a href="https://twitter.com/SoftSkillsEng?ref_src=twsrc%5Etfw">@SoftSkillsEng</a> but it is amazing, I always learn something new from them. Also all episodes have a fun and friendly feeling</p>&mdash; Daniel Peñaloza (@danp1925) <a href="https://twitter.com/danp1925/status/1153683341369122816?ref_src=twsrc%5Etfw">July 23, 2019</a></blockquote>
-
-    <blockquote class="twitter-tweet"><p lang="en" dir="ltr">I love <a href="https://twitter.com/SoftSkillsEng?ref_src=twsrc%5Etfw">@SoftSkillsEng</a> .. although it&#39;s not directly focused on technical side of Software Engineering, it takes a huge often not-discussed part of the job such as the team communication, management, ethics, etc...<br><br>The hosts are really good, I literally listen to every episode ❤️</p>&mdash; Nigo (@lenaggar) <a href="https://twitter.com/lenaggar/status/1128405640077107203?ref_src=twsrc%5Etfw">May 14, 2019</a></blockquote>
-
-    <blockquote class="twitter-tweet"><p lang="en" dir="ltr"><a href="https://twitter.com/WanderingHogan?ref_src=twsrc%5Etfw">@WanderingHogan</a> I’ve been looking for new podcasts and added <a href="https://twitter.com/SoftSkillsEng?ref_src=twsrc%5Etfw">@SoftSkillsEng</a> when you mentioned it. Just listened to EP 149 and totally relevant to me as a 40-year-old dev. Thanks for sharing! Also, nice to hear your name in the shoutouts!</p>&mdash; Andrew Serff (@andrewserff) <a href="https://twitter.com/andrewserff/status/1114300319997939712?ref_src=twsrc%5Etfw">April 5, 2019</a></blockquote>
-  </section>
 </div>
 
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>


### PR DESCRIPTION
All the content will still be on the home page, but I'm re-ordering the tweets to be above the recent episodes.

The goal is to convince potential listeners to subscribe. Targeting people who came to our web site from an ad.

## Before:
![image](https://user-images.githubusercontent.com/921044/82251723-f5284080-990a-11ea-8755-5266c2d81b4a.png)


## After:
![image](https://user-images.githubusercontent.com/921044/82251709-ed689c00-990a-11ea-88db-34ccc304a666.png)
