### PR TITLE
Centralize "Other ways to reach us"

### DIFF
--- a/ask.html
+++ b/ask.html
@@ -23,7 +23,7 @@ tags: in-nav
     <div class="block-header">
       <h2 class="block-heading text-center">Other ways to reach us:</h2>
     </div>
-    <p class="lead or-lead">
+    <p class="lead or-lead text-center">
       <a class="button" href="https://twitter.com/{{site.twitter_username}}">
         <span>Tweet Us</span>
       </a>


### PR DESCRIPTION
I noticed that this section of the site is not centered, so I fixed it:

**Before**

![before](https://github.com/soft-skills-engineering/website/assets/57065994/1af16e52-6ccf-4788-a7fe-188e0c3c53a9)
**After**

![after](https://github.com/soft-skills-engineering/website/assets/57065994/178ee20c-244e-4a20-a194-1f8e9f1b780e)

I love the show btw ❤️ 